### PR TITLE
Added Items table

### DIFF
--- a/db/20231102133812-item-table.ts
+++ b/db/20231102133812-item-table.ts
@@ -1,0 +1,51 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .createTable('items')
+        .addColumn('id', 'serial', (col) => col.primaryKey())
+        .addColumn('name', 'varchar', (col) => col.notNull())
+        .addColumn('category', 'varchar', (col) =>
+            col.defaultTo('Other').notNull()
+        )
+        .addColumn('expiration', 'timestamp', (col) => col.notNull())
+        .addColumn('quantity', 'varchar(240)', (col) =>
+            col.defaultTo(1).notNull()
+        )
+        .addColumn('household_id', 'integer', (col) =>
+            col.references('households.id').notNull()
+        )
+        .addColumn('found_in', 'varchar', (col) =>
+            col.defaultTo('Inventory').notNull()
+        )
+        .addColumn('created_at', 'timestamp', (col) =>
+            col.defaultTo(sql`now()`).notNull()
+        )
+        .addColumn('updated_at', 'timestamp', (col) =>
+            col.defaultTo(sql`now()`).notNull()
+        )
+        .execute()
+
+    await db.schema
+        .createIndex('item_household_id_index')
+        .on('items')
+        .column('household_id')
+        .execute()
+
+    await db
+        .insertInto('items')
+        .values({
+            name: 'Milk Gallon',
+            category: 'Dairy',
+            expiration: '11/20/2023',
+            quantity: 1,
+            household_id: 1,
+        })
+        .executeTakeFirst()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .dropTable('items')
+        .execute()
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -3,6 +3,7 @@ import { ColumnType, Generated, Insertable, Selectable, Updateable } from 'kysel
 export interface Database {
   households: HouseholdsTable
   users: UsersTable
+  items: ItemsTable
 }
 
 //HOUSEHOLD
@@ -34,6 +35,21 @@ export type NewUser = Insertable<UsersTable>
 export type UserUpdate = Updateable<UsersTable>
 
 //ITEM
+export interface ItemsTable {
+  id: Generated<number>
+  name: string
+  category: string
+  expiration: Date
+  quantity: string
+  household_id: number
+  found_in: string
+  created_at: ColumnType<Date, string | undefined, never>
+  updated_at: ColumnType<Date, string | undefined, never>
+}
+
+export type Item = Selectable<ItemsTable>
+export type NewItem = Insertable<ItemsTable>
+export type ItemUpdate = Updateable<ItemsTable>
 
 //RECIPE
 


### PR DESCRIPTION
Fields are self-explanatory aside from found_in.
found_in specifies where the item was added. It could be a recipe, the shopping list, or their inventory. FE will handle predetermined options based on where the item is added from.
Quantity is defaulted to 1 and does not need to be provided unless changed from 1. Category does not need to be provided either, default is Other. FE should list category options and best judgment on what should be in the drop-down list. (Dairy, grain, fruit, veg, eggs, seafood, meat are the ones I can think of)

Options for found_in:
'Inventory'
'List'
'Recipe' - May need to also add recipe ID column, either that or store item IDs on recipe but we can figure that out later.